### PR TITLE
fixing issue with resource type toggles

### DIFF
--- a/app/scripts/dashboard/dashboard.controller.js
+++ b/app/scripts/dashboard/dashboard.controller.js
@@ -400,8 +400,7 @@ define([
 
     function toggleResourceType(type) {
       vm.resourceTypes[type] = !vm.resourceTypes[type];
-      // TODO: should be cedarUser.getCurrentFolderId()
-      getFolderContents(vm.currentWorkspacePath);
+      init();
     }
 
     /**

--- a/app/scripts/dashboard/dashboard.controller.js
+++ b/app/scripts/dashboard/dashboard.controller.js
@@ -90,11 +90,11 @@ define([
       if (vm.params.folderId || vm.params.search) {
         getForms();
         getFacets();
-        if (vm.params.folderId) {
+        if (vm.params.search) {
+          doSearch(vm.params.search);
+        } else {
           vm.isSearching = false;
           getFolderContentsById(decodeURIComponent(vm.params.folderId));
-        } else {
-          doSearch(vm.params.search);
         }
       } else {
         vm.isSearching = false;


### PR DESCRIPTION
This fixes this issue:

(1) Clicking on the resource type filters resets the current folder to the user's home directly no matter where they were in the hierarchy when clicking it.