### PR TITLE
fix for going back in editors and passing folderId

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -49,7 +49,7 @@
           </form>
         </div>
       </div>
-      <a class="navbar-brand" href="/dashboard">Cedar</a>
+      <a class="navbar-brand" ng-click="hc.goToDashboardOrBack()" href="javascript:">Cedar</a>
 
       <div id="jsonTools" cedar-position-json-tools="true" ng-if="!hc.showSearch()">
         <a id='show-json-link' ng-click="$root.showRender = !$root.showRender; $root.scrollToAnchor('templateJSON')"

--- a/app/scripts/dashboard/dashboard.controller.js
+++ b/app/scripts/dashboard/dashboard.controller.js
@@ -187,14 +187,27 @@ define([
     
     function launchInstance(resource) {
       var params = $location.search();
-      var folderId;
+      var folderId, url;
+
       if (params.folderId) {
         folderId = params.folderId;
+        url = UrlService.getInstanceCreate(resource['@id'], folderId);
+        $location.url(url);
       } else {
-        folderId = vm.currentFolderId
+        // in search - look up resource to find its parent
+        // place instance next to template
+        resourceService.getResourceDetail(
+          resource,
+          function(response) {
+            folderId = response.parentFolderId;
+            url = UrlService.getInstanceCreate(resource['@id'], folderId);
+            $location.url(url);
+          },
+          function(error) {
+            UIMessageService.showBackendError('SERVER.'+resource.resourceType.toUpperCase()+'.load.error', error);
+          }
+        );
       }
-      var url = UrlService.getInstanceCreate(resource['@id'], folderId);
-      $location.url(url);
     }
 
     function goToResource(resource) {

--- a/app/scripts/layout/header.controller.js
+++ b/app/scripts/layout/header.controller.js
@@ -15,9 +15,25 @@ define([
   function HeaderController($rootScope, $location, UrlService) {
     var vm = this;
 
+    vm.goToDashboardOrBack = goToDashboardOrBack;
     vm.search = search;
     vm.searchTerm = null;
     vm.showSearch = showSearch;
+
+    function goToDashboardOrBack() {
+      var params = $location.search();
+      var path   = $location.path();
+      var url    = '/dashboard';
+      if (path != url) {
+        if (params.folderId) {
+          url += '?folderId=' + encodeURIComponent(params.folderId);
+        }
+        if (params.search) {
+          url += '?search=' + encodeURIComponent(params.search);
+        }
+      }
+      $location.url(url);
+    };
 
     function showSearch() {
       return $rootScope.showSearch;


### PR DESCRIPTION
Fixes for:

(2) Cannot populate a template from either the Populate a Form area or the in search result mode because the current folder is not supplied to the call. Atti will follow up on details for fixing this issue.

(3) On return from the template and element editors the current folder is reset to the user's home folder. Again, Atti will follow with details on a fix.