### PR TITLE
Make template editor work at http://localhost:4200

### DIFF
--- a/app/config/src/version.js
+++ b/app/config/src/version.js
@@ -5,3 +5,4 @@ window.versioningEnabled = true;
 window.makeOpenEnabled = true;
 window.categoryTreeEnabled = true;
 window.dataciteEnabled = dataciteEnabledValue;
+window.authBase = "authBaseValue";

--- a/app/scripts/handlers/KeycloakUserHandler.js
+++ b/app/scripts/handlers/KeycloakUserHandler.js
@@ -1,8 +1,10 @@
-function KeycloakUserHandler() {
+function KeycloakUserHandler(UrlService) {
 
   const keycloak = Keycloak({
     "realm"   : "CEDAR",
-    "url"     : window.location.origin.replaceAll('/cedar.', '/auth.'),
+    "url"     : window.location.origin.startsWith("http://localhost:4200") ?
+                  window.location.origin.replaceAll("http://localhost:4200", window.authBase) :
+                  window.location.origin.replaceAll('/cedar.', '/auth.'),
     "clientId": "cedar-angular-app"
   });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,6 +97,7 @@ gulp.task('replace-url', function (done) {
       .pipe(replace('impexServerUrl', 'https://impex.' + cedarRestHost))
       .pipe(replace('artifactsFrontendUrl', 'https://artifacts.' + cedarRestHost))
       .pipe(replace('dataciteDOIBaseUrl', 'https://bridging.' + cedarRestHost + '/doi/datacite'))
+      .pipe(replace('authServerUrl', 'https://auth.' + cedarRestHost))
       .pipe(gulp.dest('app/config/'));
   done();
 });
@@ -115,6 +116,7 @@ gulp.task('replace-version', function (done) {
       .pipe(replace('cedarVersionValue', cedarVersion))
       .pipe(replace('cedarVersionModifierValue', cedarVersionModifier))
       .pipe(replace('dataciteEnabledValue', dataciteEnabled))
+      .pipe(replace('authBaseValue', 'https://auth.' + cedarRestHost))
       .pipe(gulp.dest('app/config/'));
   done();
 });


### PR DESCRIPTION
Changed the way KeycloakUserHandler calculates the auth endpoint when editor is run at http://localhost:4200. For now it takes the value from window.authBase set in version.js by gulpfile.js. There's surely a better way to do this.

For this to work  keycloak-realm.CEDAR.development.2023-07-05.json also needs to be updated in cedar-docker-build:
{
    "clientId" : "cedar-angular-app",
    ...
    "redirectUris" : [ ..., "http://localhost:4200", "http://localhost:4200/*"],
    "webOrigins" : [ ..., "http://localhost:4200", "http://localhost:4200/*"],
 }